### PR TITLE
retry event loops

### DIFF
--- a/batch/server.py
+++ b/batch/server.py
@@ -272,8 +272,6 @@ def kube_event_loop():
         pod = event['object']
         name = pod.metadata.name
 
-        # too much
-        # log.debug(f'kube_event_loop: got event {event}')
         log.debug(f'kube_event_loop: got event: {event_type} {pod.api_version}/{pod.kind} {name}')
 
         job = pod_name_job.get(name)


### PR DESCRIPTION
Fixes https://github.com/hail-is/batch/issues/10

Retry kube and flask event loops on any error (or return) no faster than approximately 15s.  Since I subtract off the time of the previous run and we assume the event loops will generally be long-lived, in the common case the event loop will be restarted immediately.

Tested by injecting faults into the kube event loop and running the tests.  Worked fine, but just took a little longer.

```
diff --git a/batch/server.py b/batch/server.py
index 7ea3a95..3dd05dc 100644
--- a/batch/server.py
+++ b/batch/server.py
@@ -266,19 +266,12 @@ def flask_event_loop():
     app.run(debug=True, host='0.0.0.0')
 
 def kube_event_loop():
-    saw_non_add = False
-    
     stream = kube.watch.Watch().stream(v1.list_namespaced_pod, 'default')
     for event in stream:
         event_type = event['type']
         pod = event['object']
         name = pod.metadata.name
 
-        if event_type != 'ADDED':
-            saw_non_add = True
-        if saw_non_add and random.random() < 0.1:
-            raise ValueError('kube_event_loop injected fault')
-
         # too much
         # log.debug(f'kube_event_loop: got event {event}')
         log.debug(f'kube_event_loop: got event: {event_type} {pod.api_version}/{pod.kind} {name}')
```

I log the exception with the Python logging exc_info parameter, and the log entries look like:

```
ERROR:batch:run_forever: target kube_event_loop threw exception
Traceback (most recent call last):
  File "batch/server.py", line 253, in run_forever
    target(*args, **kwargs)
  File "batch/server.py", line 280, in kube_event_loop
    raise ValueError('kube_event_loop injected fault')
ValueError: kube_event_loop injected fault
```
