### PR TITLE
Job delete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,4 @@ run:
 	BATCH_USE_KUBE_CONFIG=1 python batch/server.py
 
 test-local:
-	POD_IP='127.0.0.1' BATCH_URL='http://127.0.0.1:5000' python -m unittest test/test_batch.py
+	POD_IP='127.0.0.1' BATCH_URL='http://127.0.0.1:5000' python -m unittest -v test/test_batch.py

--- a/batch/api.py
+++ b/batch/api.py
@@ -27,7 +27,7 @@ def get_job(url, job_id):
     return r.json()
 
 def delete_job(url, job_id):
-    r = requests.post(url + '/jobs/{}/delete'.format(job_id))
+    r = requests.delete(url + '/jobs/{}/delete'.format(job_id))
     r.raise_for_status()
     return r.json()
 

--- a/batch/api.py
+++ b/batch/api.py
@@ -26,6 +26,11 @@ def get_job(url, job_id):
     r.raise_for_status()
     return r.json()
 
+def delete_job(url, job_id):
+    r = requests.post(url + '/jobs/{}/delete'.format(job_id))
+    r.raise_for_status()
+    return r.json()
+
 def cancel_job(url, job_id):
     r = requests.post(url + '/jobs/{}/cancel'.format(job_id))
     r.raise_for_status()

--- a/batch/client.py
+++ b/batch/client.py
@@ -44,6 +44,13 @@ class Job(object):
     def cancel(self):
         self.client._cancel_job(self.id)
 
+    def delete(self):
+        self.client._delete_job(self.id)
+        
+        self.id = None
+        self.attributes = None
+        self._status = None
+
 class Batch(object):
     def __init__(self, client, id):
         self.client = client
@@ -119,6 +126,9 @@ class BatchClient(object):
 
     def _get_job(self, id):
         return api.get_job(self.url, id)
+
+    def _delete_job(self, id):
+        api.delete_job(self.url, id)
 
     def _cancel_job(self, id):
         api.cancel_job(self.url, id)

--- a/hail-ci-build.sh
+++ b/hail-ci-build.sh
@@ -8,8 +8,4 @@ sleep 5
 POD_IP='127.0.0.1' BATCH_URL='http://127.0.0.1:5000' python -m unittest test/test_batch.py
 EXIT_CODE=$?
 
-curl -X POST http://127.0.0.1:5000/shutdown
-
-wait
-
 exit $EXIT_CODE

--- a/test/test_batch.py
+++ b/test/test_batch.py
@@ -77,6 +77,20 @@ class Test(unittest.TestCase):
         status = j.wait()
         self.assertEqual(status['exit_code'], 1)
 
+    def test_delete_job(self):
+        j = self.batch.create_job('alpine', ['sleep', '30'])
+        id = j.id
+        j.delete()
+
+        # verify doesn't exist
+        try:
+            self.batch._get_job(id)
+        except requests.HTTPError as e:
+            if e.response.status_code == 404:
+                pass
+            else:
+                raise
+
     def test_cancel_job(self):
         j = self.batch.create_job('alpine', ['sleep', '30'])
         status = j.status()
@@ -85,6 +99,24 @@ class Test(unittest.TestCase):
         j.cancel()
         status = j.status()
         self.assertTrue(status['state'], 'Cancelled')
+
+    def test_get_nonexistent_job(self):
+        try:
+            self.batch._get_job(666)
+        except requests.HTTPError as e:
+            if e.response.status_code == 404:
+                pass
+            else:
+                raise
+
+    def test_api_cancel_nonexistent_job(self):
+        try:
+            self.batch._cancel_job(666)
+        except requests.HTTPError as e:
+            if e.response.status_code == 404:
+                pass
+            else:
+                raise
 
     def test_get_job(self):
         j = self.batch.create_job('alpine', ['true'])


### PR DESCRIPTION
Few things:
 - removed shutdown logic, just exit in hail-ci-build.sh, don't try to gracefully shut down server
 - added `/jobs/N/delete` endpoint, addressed part of: https://github.com/hail-is/batch/issues/16
 - added requests timeout
 - test get_job and cancel_job return `requests.HTTPError` with status 404 for non-existent job, fixes https://github.com/hail-is/batch/issues/18

The client should probably have its own NoSuchJob exception.
